### PR TITLE
#5 | adjust the connect page style to fit low resolutions

### DIFF
--- a/ui/src/components/ConnectWallet.vue
+++ b/ui/src/components/ConnectWallet.vue
@@ -50,6 +50,13 @@ const { connectors, connect } = useConnect();
     text-align: center;
     margin: 30px;
     margin-top: -200px;
+
+    // on low resolution screens
+    @media (max-width: 600px) {
+      font-size: 22px;
+      margin: 14px;
+      margin-top: -100px;
+    }
   }
 
   &--card {


### PR DESCRIPTION
# Fixes #5

## Description
This PR adds a title of styling for the connect page to look better on low resolution devices

![image](https://github.com/user-attachments/assets/e065da97-e715-440e-82da-086899409081)
